### PR TITLE
Rate limiting using Flask-Limiter

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ dictConfig(
     }
 )
 
-RATELIMIT_STORAGE_URL = os.environ.get("RATELIMIT_STORAGE_URL", "memory://")
+RATELIMIT_STORAGE_URI = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
 
 app = Flask(__name__)
 app.config.from_prefixed_env()
@@ -38,7 +38,7 @@ limiter = Limiter(
     get_remote_address,
     app=app,
     default_limits=["200 per day", "50 per hour"],
-    storage_uri=RATELIMIT_STORAGE_URL,
+    storage_uri=RATELIMIT_STORAGE_URI,
 )
 
 # Use the DATABASE_URL environment variable if it exists, otherwise use the default.

--- a/app.py
+++ b/app.py
@@ -29,6 +29,8 @@ dictConfig(
     }
 )
 
+RATELIMIT_STORAGE_URL = os.environ.get("RATELIMIT_STORAGE_URL", "memory://")
+
 app = Flask(__name__)
 app.config.from_prefixed_env()
 log = app.logger
@@ -36,7 +38,7 @@ limiter = Limiter(
     get_remote_address,
     app=app,
     default_limits=["200 per day", "50 per hour"],
-    storage_uri="redis://redis:6379/",
+    storage_uri=RATELIMIT_STORAGE_URL,
 )
 
 # Use the DATABASE_URL environment variable if it exists, otherwise use the default.

--- a/app.py
+++ b/app.py
@@ -5,11 +5,10 @@ import os
 from logging.config import dictConfig
 
 from flask import Flask, jsonify, request
-from psycopg.rows import namedtuple_row
-from psycopg_pool import ConnectionPool
-
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from psycopg.rows import namedtuple_row
+from psycopg_pool import ConnectionPool
 
 dictConfig(
     {
@@ -37,7 +36,7 @@ limiter = Limiter(
     get_remote_address,
     app=app,
     default_limits=["200 per day", "50 per hour"],
-    storage_uri="redis://redis:6379/"
+    storage_uri="redis://redis:6379/",
 )
 
 # Use the DATABASE_URL environment variable if it exists, otherwise use the default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython>=0.29.24
 Flask>=3.0.1
-Flask-Limiter[redis]
+Flask-Limiter[redis]>=3.8.0
 gunicorn>=23.0.0
 packaging==23
 psycopg[binary,pool]>=3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ packaging==23
 psycopg[binary,pool]>=3.2.1
 Werkzeug[watchdog]>=3.0.1
 wheel
+Flask-Limiter[redis]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 cython>=0.29.24
 Flask>=3.0.1
+Flask-Limiter[redis]
 gunicorn>=23.0.0
 packaging==23
 psycopg[binary,pool]>=3.2.1
 Werkzeug[watchdog]>=3.0.1
 wheel
-Flask-Limiter[redis]


### PR DESCRIPTION
- Added rate limiting to api using Flask-Limiter and Redis.
- Flask-Limiter is configured to use a redis instance located in `redis:6379` (like the one present in the docker compose of [bdist-workpspace](https://github.com/bdist/bdist-workspace))
- Also added some examples of default rate limits (applied to all routes that do not have an explicit decorator), route-specific rate limits and limit exemption for certain routes.